### PR TITLE
context.sideload_allowlist prevented preloading of nested sideloads

### DIFF
--- a/spec/query_spec.rb
+++ b/spec/query_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe Graphiti::Query do
         end
       end
 
-      context "when context has sideload allowlist" do
+      context "when context has #sideload_allowlist" do
         let(:ctx) do
           OpenStruct.new(sideload_allowlist: {update: {positions: {}}})
         end
@@ -60,6 +60,22 @@ RSpec.describe Graphiti::Query do
 
         it "removes invalid includes" do
           expect(hash).to eq(include: {positions: {}})
+        end
+      end
+
+      context "when context has #sideload_allowlist with nested resources" do
+        let(:ctx) do
+          OpenStruct.new(sideload_allowlist: {update: {positions: {department: {}}}})
+        end
+
+        around do |e|
+          Graphiti.with_context ctx, :update do
+            e.run
+          end
+        end
+
+        it "correctly constructs include hashes for nested queries" do
+          expect(instance.sideload_hash[:positions]).to eq({:include=>{:department=>{}}})
         end
       end
 


### PR DESCRIPTION
`context.sideload_allowlist` only worked correctly for the top-level of sideloads

✅ `orders/:id?include=lines` does a single query for all lines
❌ `orders/:id?include=lines.item` does N+1 queries for the items

This was caused by the fact that **nested** queries use `context.sideload_allowlist`, which describes the allowed sideloads for the **top-level** resource.

![Screenshot 2024-06-20 at 13 29 17](https://github.com/booqable/graphiti/assets/396336/42b38987-5950-449f-b2a1-f91583515c72)
