### PR TITLE
Rails7.1: DEPRECATION WARNING: Bolding log text with a positional boolean is deprecated

### DIFF
--- a/lib/graphiti.rb
+++ b/lib/graphiti.rb
@@ -84,7 +84,7 @@ module Graphiti
   end
 
   def self.log(msg, color = :white, bold = false)
-    colored = ActiveSupport::LogSubscriber.new.send(:color, msg, color, bold)
+    colored = ActiveSupport::LogSubscriber.new.send(:color, msg, color, bold: true)
     logger.debug(colored)
   end
 


### PR DESCRIPTION
Fixes: 

```
DEPRECATION WARNING: Bolding log text with a positional boolean is deprecated and will be
removed in Rails 7.2. Use an option hash instead (eg. `color("my text", :red, bold: true)`).
(called from block in call at lib/tenant_on_request.rb:18)
(ActiveSupport::DeprecationException)
```

Upstream fix: https://github.com/graphiti-api/graphiti/commit/34e9f8e828db5fda97247dc4a2b177a2bea8f181